### PR TITLE
Adiciona documentação do planejamento da Sprint 1

### DIFF
--- a/docs/assets/css/extra.css
+++ b/docs/assets/css/extra.css
@@ -1,0 +1,7 @@
+.md-typeset__table {
+  min-width: 100%;
+}
+
+.md-typeset table:not([class]) {
+  display: table;
+}

--- a/docs/management/sprints/sprint-1-planning.md
+++ b/docs/management/sprints/sprint-1-planning.md
@@ -2,36 +2,37 @@
 
 ## Histórico de revisão
 
-| Data       | Autor                                                | Modificações                      | Versão |
-| ---------- | ---------------------------------------------------- | --------------------------------- | ------ |
+| Data       | Autor                                                | Modificações                                      | Versão |
+| ---------- | ---------------------------------------------------- | ------------------------------------------------- | ------ |
 | 24/02/2020 | [Leonardo Medeiros](https://github.com/leomedeiros1) | Adiciona documentação de planejamento da sprint 1 | 1.0    |
+| 24/02/2020 | [Welison Regis](https://github.com/WelisonR)         | Melhorias na diagramação da página                | 1.1    |
 
 ## Tamanho da sprint
-* Início: 13/02/2021
-* Término: 20/02/2021
-* Duração: 7 dias
+
+| Início da sprint | Término da Sprint | Duração |
+| :--------------: | :---------------: | :-----: |
+|    13/02/2021    |    20/02/2021     | 7 dias  |
 
 ## Pareamentos
 
-Para esta sprint os pares e suas designações foram definidos com base nas tarefas e na afinidade dos membros. 
-Os membros do time de MDS ficaram responsáveis apenas pelo levantamento de ideias para discussão com o cliente,
-além de participar dos treinamentos e estudar as tecnologias.
+Para esta sprint os pares e suas designações foram definidos com base nas tarefas e na afinidade dos membros.
+Nessa sprint, o time de modo geral ficará responsável pelo levantamento de ideias para discussão com o cliente. A equipe de MDS estudará as tecnologias e os materiais passados por EPS, além de participar de treinamentos; já a equipe de EPS, estará focada nas pendências de documentação importantes para o repositório.
 
-| Pareamento   | Autor                           |
-| ------------ | ------------------------------- | 
-|      1       | Welison Regis e Lieverton Silva |
-|      2       | André Pinto e Leonardo Medeiros |
+| Pareamento | Membros                         |
+| :--------: | ------------------------------- |
+|     1      | Welison Regis e Lieverton Silva |
+|     2      | André Pinto e Leonardo Medeiros |
 
 ## Sprint Backlog
 
-| Issue | Pontos | Responsáveis |
-| ----- | ------ | ------------ |
-|[Criar documento de contribuição do repositório](https://github.com/fga-eps-mds/EPS-2020-2-G3/issues/5)| 3 | Lieverton Silva e Welison Regis |
-|[Criar documento de código de conduta](https://github.com/fga-eps-mds/EPS-2020-2-G3/issues/12)| 2 | Leonardo Medeiros |
-|[Criar landing page para a wiki](https://github.com/fga-eps-mds/EPS-2020-2-G3/issues/15)| 5 | Lieverton Silva |
-|[Documentar sprint 0](https://github.com/fga-eps-mds/EPS-2020-2-G3/issues/18)| 5 | Welison Regis |
-|[Dojo de python e programação orientada a objetos](https://github.com/fga-eps-mds/EPS-2020-2-G3/issues/19)| 8 | André Pinto e Leonardo Medeiros |
-|[Levantamento de dúvidas sobre o projeto](https://github.com/fga-eps-mds/EPS-2020-2-G3/issues/22)| 1 | Todos os membros |
+| Issue                                                                                                      | Pontos | Responsáveis                    |
+| ---------------------------------------------------------------------------------------------------------- | :----: | ------------------------------- |
+| [Criar documento de contribuição do repositório](https://github.com/fga-eps-mds/EPS-2020-2-G3/issues/5)    |   3    | Lieverton Silva e Welison Regis |
+| [Criar documento de código de conduta](https://github.com/fga-eps-mds/EPS-2020-2-G3/issues/12)             |   2    | Leonardo Medeiros               |
+| [Criar landing page para a wiki](https://github.com/fga-eps-mds/EPS-2020-2-G3/issues/15)                   |   5    | Lieverton Silva                 |
+| [Documentar sprint 0](https://github.com/fga-eps-mds/EPS-2020-2-G3/issues/18)                              |   5    | Welison Regis                   |
+| [Dojo de python e programação orientada a objetos](https://github.com/fga-eps-mds/EPS-2020-2-G3/issues/19) |   8    | André Pinto e Leonardo Medeiros |
+| [Levantamento de dúvidas sobre o projeto](https://github.com/fga-eps-mds/EPS-2020-2-G3/issues/22)          |   1    | Todos os membros                |
 
 ## Papéis
 

--- a/docs/management/sprints/sprint-1-planning.md
+++ b/docs/management/sprints/sprint-1-planning.md
@@ -1,0 +1,38 @@
+# Planejamento da sprint 1
+
+## Histórico de revisão
+
+| Data       | Autor                                                | Modificações                      | Versão |
+| ---------- | ---------------------------------------------------- | --------------------------------- | ------ |
+| 24/02/2020 | [Leonardo Medeiros](https://github.com/leomedeiros1) | Adiciona documentação de planejamento da sprint 1 | 1.0    |
+
+## Tamanho da sprint
+* Início: 13/02/2021
+* Término: 20/02/2021
+* Duração: 7 dias
+
+## Pareamentos
+
+Para esta sprint os pares e suas designações foram definidos com base nas tarefas e na afinidade dos membros. 
+Os membros do time de MDS ficaram responsáveis apenas pelo levantamento de ideias para discussão com o cliente,
+além de participar dos treinamentos e estudar as tecnologias.
+
+| Pareamento   | Autor                           |
+| ------------ | ------------------------------- | 
+|      1       | Welison Regis e Lieverton Silva |
+|      2       | André Pinto e Leonardo Medeiros |
+
+## Sprint Backlog
+
+| Issue | Pontos | Responsáveis |
+| ----- | ------ | ------------ |
+|[Criar documento de contribuição do repositório](https://github.com/fga-eps-mds/EPS-2020-2-G3/issues/5)| 3 | Lieverton Silva e Welison Regis |
+|[Criar documento de código de conduta](https://github.com/fga-eps-mds/EPS-2020-2-G3/issues/12)| 2 | Leonardo Medeiros |
+|[Criar landing page para a wiki](https://github.com/fga-eps-mds/EPS-2020-2-G3/issues/15)| 5 | Lieverton Silva |
+|[Documentar sprint 0](https://github.com/fga-eps-mds/EPS-2020-2-G3/issues/18)| 5 | Welison Regis |
+|[Dojo de python e programação orientada a objetos](https://github.com/fga-eps-mds/EPS-2020-2-G3/issues/19)| 8 | André Pinto e Leonardo Medeiros |
+|[Levantamento de dúvidas sobre o projeto](https://github.com/fga-eps-mds/EPS-2020-2-G3/issues/22)| 1 | Todos os membros |
+
+## Papéis
+
+Para esta sprint os papéis ainda não haviam sido totalmente definidos.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -42,8 +42,8 @@ nav:
         - Planejamento: "management/sprints/sprint-1-planning.md"
 
 # Style
-# extra_css:
-#   - assets/style/extra.css
+extra_css:
+  - assets/css/extra.css
 
 # Markdown extensions
 markdown_extensions:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -38,6 +38,8 @@ nav:
     - Sprints:
       - Sprint 0:
         - Revisão e retrospectiva: "management/sprints/sprint-0.md"
+      - Sprint 1:
+        - Planejamento: "management/sprints/sprint-1-planning.md"
 
 # Style
 # extra_css:


### PR DESCRIPTION
## Descrição 

Adiciona documentação do planejamento da sprint 1 para a wiki.

**Resolve issue #27**

## Tarefas realizadas

- [x] Documenta planejamento da sprint;
- [x] Adiciona quadro de distribuição das tarefas na wiki.
