### PR TITLE
Adiciona planejamento da sprint 5 para a wiki

### DIFF
--- a/docs/management/sprints/sprint-5-planning.md
+++ b/docs/management/sprints/sprint-5-planning.md
@@ -1,0 +1,45 @@
+# Planejamento da sprint 5
+
+## Histórico de revisão
+
+|    Data    | Autor                                           | Modificações                      | Versão |
+| :--------: | ----------------------------------------------- | --------------------------------- | :----: |
+| 23/03/2021 | [Welison Regis](http://www.github.com/WelisonR) | Adiciona planejamento da sprint 5 |  1.0   |
+
+## Tamanho da sprint
+
+| Início da sprint | Término da Sprint | Duração |
+| :--------------: | :---------------: | :-----: |
+|    14/03/2021    |    20/03/2021     | 7 dias  |
+
+## Pareamentos
+
+| Paramento | Integrantes                                                                                            |
+| :-------: | ------------------------------------------------------------------------------------------------------ |
+|     1     | [Luís Guilherme](http://www.github.com/luisgaboardi) e [Luiz Gustavo](http://www.github.com/LightZX)   |
+|     2     | [Ana Júlia](http://www.github.com/aluzianobriceno) e [Lais Portela](http://www.github.com/laispa)      |
+|     3     | [Fernando Vargas](http://www.github.com/SFernandoS) e [Lucas Rodrigues](http://www.github.com/nickby2) |
+
+## Sprint Backlog
+
+| Issue                                                                                                                    | Pontos | Responsáveis                                                                                             |
+| ------------------------------------------------------------------------------------------------------------------------ | :----: | -------------------------------------------------------------------------------------------------------- |
+| [Criar seed das bases de dados do backend](https://github.com//fga-eps-mds/2020.2-Projeto-Kokama-Wiki/issues/76)         |   5    | [Lieverton Silva](https://github.com/lievertom)                                                          |
+| [Adicionar configurações de lint locais](https://github.com//fga-eps-mds/2020.2-Projeto-Kokama-Wiki/issues/77)           |   8    | [Leonardo Medeiros](https://github.com/leomedeiros1)                                                     |
+| [Criar documento de planejamento da sprint 5](https://github.com//fga-eps-mds/2020.2-Projeto-Kokama-Wiki/issues/97)      |   2    | [Welison Regis](https://github.com/WelisonR)                                                             |
+| [Documentar revisão e retrospectiva da sprint 4](https://github.com//fga-eps-mds/2020.2-Projeto-Kokama-Wiki/issues/98)   |   5    | [Welison Regis](https://github.com/WelisonR)                                                             |
+| [Criar diagrama de pacotes da aplicação](https://github.com//fga-eps-mds/2020.2-Projeto-Kokama-Wiki/issues/99)           |   3    | [Lieverton Silva](https://github.com/lievertom)                                                          |
+| [Configurar ferramenta SonarQube nos repositórios](https://github.com//fga-eps-mds/2020.2-Projeto-Kokama-Wiki/issues/92) |   5    | [André Lucas](https://github.com/andrelucax) e [Lieverton Silva](https://github.com/lievertom)           |
+| [[TS01] Melhorias na página de tradução](https://github.com//fga-eps-mds/2020.2-Projeto-Kokama-Wiki/issues/96)           |   8    | [Luís Guilherme](https://github.com/luisgaboardi) e [Luiz Gustavo](https://github.com/LightZX)           |
+| [[US04] Inserção de caracter especial](https://github.com//fga-eps-mds/2020.2-Projeto-Kokama-Wiki/issues/93)             |   5    | [Luís Guilherme](https://github.com/luisgaboardi) e [Luiz Gustavo](https://github.com/LightZX)           |
+| [[US05] Histórico de palavras pesquisadas](https://github.com/fga-eps-mds/2020.2-Projeto-Kokama-Wiki/issues/95)          |   5    | [Fernando Vargas](https://www.github.com/SFernandoS) e [Lucas Rodrigues](https://www.github.com/nickby2) |
+| [[US06] Atualizar dicionário de palavras](https://github.com/fga-eps-mds/2020.2-Projeto-Kokama-Wiki/issues/94)           |   8    | [Ana Júlia](https://www.github.com/aluzianobriceno) e [Lais Portela](https://www.github.com/laispa)      |
+
+## Papéis
+
+|         Papel         | Integrante        |
+| :-------------------: | ----------------- |
+|   **Scrum Master**    | Welison Regis     |
+|      **DevOps**       | Leonardo Medeiros |
+|     **Arquiteto**     | Lieverton Santos  |
+| **Analista de dados** | André Pinto       |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -74,6 +74,8 @@ nav:
       - Sprint 4:
         - Planejamento: "management/sprints/sprint-4-planning.md"
         - Revisão e retrospectiva: "management/sprints/sprint-4-review-retrospective.md"
+      - Sprint 5:
+        - Planejamento: "management/sprints/sprint-5-planning.md"
     - Reuniões com PO:
       - Reunião 1: "management/po-meetings/meeting-1.md" 
       - Reunião 2: "management/po-meetings/meeting-2.md" 


### PR DESCRIPTION
## Descrição 

Adiciona documentação do planejamento da sprint 5 para a wiki.

**Resolve #97**

## Tarefas realizadas

- [x] Adiciona informações sobre a sprint;
- [x] Adiciona pareamentos da sprint;
- [x] Adiciona atividades mapeadas para a sprint;
- [x] Adiciona papéis dos membros de EPS na sprint.