### PR TITLE
Adiciona planejamento da sprint 7 para a wiki

### DIFF
--- a/docs/management/sprints/sprint-7-planning.md
+++ b/docs/management/sprints/sprint-7-planning.md
@@ -1,0 +1,47 @@
+# Planejamento da sprint 7
+
+## Histórico de revisão
+
+|    Data    | Autor                                           | Modificações                      | Versão |
+| :--------: | ----------------------------------------------- | --------------------------------- | :----: |
+| 01/04/2021 | [Welison Regis](http://www.github.com/WelisonR) | Adiciona planejamento da sprint 7 |  1.0   |
+
+## Tamanho da sprint
+
+| Início da sprint | Término da Sprint | Duração |
+| :--------------: | :---------------: | :-----: |
+|    28/03/2021    |    03/04/2021     | 7 dias  |
+
+## Pareamentos
+
+| Paramento | Integrantes                                                                                            |
+| :-------: | ------------------------------------------------------------------------------------------------------ |
+|     1     | [Ana Júlia](http://www.github.com/aluzianobriceno) e [Luiz Gustavo](http://www.github.com/LightZX)     |
+|     2     | [Fernando Vargas](http://www.github.com/SFernandoS) e [Lucas Rodrigues](http://www.github.com/nickby2) |
+|     3     | [Lais Portela](http://www.github.com/laispa) e [Luís Guilherme](http://www.github.com/luisgaboardi)    |
+
+## Sprint Backlog
+
+| Issue                                                                                                                                                    | Pontos | Responsáveis                                                                                                                                                                                       |
+| -------------------------------------------------------------------------------------------------------------------------------------------------------- | :----: | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [Automatizar processo de release do projeto](https://github.com//fga-eps-mds/2020.2-Projeto-Kokama-Wiki/issues/125)                                      |   5    | [André Lucas](https://github.com/andrelucax) e [Leonardo Medeiros](https://github.com/leomedeiros1)                                                                                                |
+| [Documentar revisão e retrospectiva da sprint 6](https://github.com//fga-eps-mds/2020.2-Projeto-Kokama-Wiki/issues/132)                                  |   5    | [Welison Regis](https://github.com/WelisonR)                                                                                                                                                       |
+| [Criar documento de planejamento da sprint 7](https://github.com//fga-eps-mds/2020.2-Projeto-Kokama-Wiki/issues/131)                                     |   2    | [Welison Regis](https://github.com/WelisonR)                                                                                                                                                       |
+| [Documentar reunião com a PO (05/03)](https://github.com//fga-eps-mds/2020.2-Projeto-Kokama-Wiki/issues/130)                                             |   3    | [Welison Regis](https://github.com/WelisonR)                                                                                                                                                       |
+| [Documentar reunião com a PO (12/03)](https://github.com//fga-eps-mds/2020.2-Projeto-Kokama-Wiki/issues/129)                                             |   3    | [Lieverton Silva](https://github.com/lievertom)                                                                                                                                                    |
+| [Criar seed para popular as tabelas de história do povo kokama](https://github.com//fga-eps-mds/2020.2-Projeto-Kokama-Wiki/issues/128)                   |   3    | [Lieverton Silva](https://github.com/lievertom)                                                                                                                                                    |
+| [Configurar testes nos repositórios do projeto](https://github.com//fga-eps-mds/2020.2-Projeto-Kokama-Wiki/issues/127)                                   |   8    | [André Lucas](https://github.com/andrelucax), [Leonardo Medeiros](https://github.com/leomedeiros1), [Lieverton Silva](https://github.com/lievertom) e [Welison Regis](https://github.com/WelisonR) |
+| [Criar ambiente de homologação para o front-end](https://github.com//fga-eps-mds/2020.2-Projeto-Kokama-Wiki/issues/126)                                  |   5    | [Leonardo Medeiros](https://github.com/leomedeiros1)                                                                                                                                               |
+| [[US02] Navegação entre menus da aplicação](https://github.com//fga-eps-mds/2020.2-Projeto-Kokama-Wiki/issues/83)                                        |   8    | [Ana Júlia](https://github.com/aluzianobriceno) e [Luiz Gustavo](https://github.com/LightZX)                                                                                                       |
+| [[US11] Cadastrar, editar e remover história do povo kokama](https://github.com//fga-eps-mds/2020.2-Projeto-Kokama-Wiki/issues/122)                      |   8    | [Lucas Rodrigues](https://github.com/nickby2) e [Fernando Vargas](https://github.com/SFernandoS)                                                                                                   |
+| [[US12] Página com história do povo Kokama](https://github.com//fga-eps-mds/2020.2-Projeto-Kokama-Wiki/issues/123)                                       |   13   | [Ana Júlia](https://github.com/aluzianobriceno) e [Luiz Gustavo](https://github.com/LightZX)                                                                                                       |
+| [[TS03] Melhorar usabilidade das paginas de cadastro, edição e lista de tradução](https://github.com//fga-eps-mds/2020.2-Projeto-Kokama-Wiki/issues/104) |   13   | [Lais Portela](https://github.com/laispa) e [Luís Guilherme](https://github.com/luisgaboardi)                                                                                                      |
+
+## Papéis
+
+|         Papel         | Integrante        |
+| :-------------------: | ----------------- |
+|   **Scrum Master**    | Welison Regis     |
+|      **DevOps**       | Leonardo Medeiros |
+|     **Arquiteto**     | Lieverton Santos  |
+| **Analista de dados** | André Pinto       |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -83,6 +83,8 @@ nav:
         - Revisão e retrospectiva: "management/sprints/sprint-5-review-retrospective.md"
       - Sprint 6:
         - Planejamento: "management/sprints/sprint-6-planning.md"
+      - Sprint 7:
+        - Planejamento: "management/sprints/sprint-7-planning.md"
     - Reuniões com PO:
       - Reunião 1: "management/po-meetings/meeting-1.md" 
       - Reunião 2: "management/po-meetings/meeting-2.md" 


### PR DESCRIPTION
## Descrição 

Adiciona documentação do planejamento da sprint 7 para a wiki.

**Resolve #131**

## Tarefas realizadas

- [x] Adiciona informações sobre a sprint;
- [x] Adiciona pareamentos da sprint;
- [x] Realiza adaptação nos pareamentos para atingir melhor produtividade nas entregas da equipe;
- [x] Adiciona atividades mapeadas para a sprint;
- [x] Adiciona papéis dos membros de EPS na sprint.