### PR TITLE
Adiciona planejamento da sprint 9 para a wiki

### DIFF
--- a/docs/management/sprints/sprint-9-planning.md
+++ b/docs/management/sprints/sprint-9-planning.md
@@ -1,0 +1,46 @@
+# Planejamento da sprint 9
+
+## Histórico de revisão
+
+|    Data    | Autor                                           | Modificações                      | Versão |
+| :--------: | ----------------------------------------------- | --------------------------------- | :----: |
+| 27/04/2021 | [Welison Regis](http://www.github.com/WelisonR) | Adiciona planejamento da sprint 9 |  1.0   |
+
+## Tamanho da sprint
+
+| Início da sprint | Término da Sprint | Duração |
+| :--------------: | :---------------: | :-----: |
+|    11/04/2021    |    17/04/2021     | 7 dias  |
+
+## Pareamentos
+
+| Paramento | Integrantes                                                                                                |
+| :-------: | ---------------------------------------------------------------------------------------------------------- |
+|     1     | [Ana Júlia](http://www.github.com/aluzianobriceno) e [Lais Portela](http://www.github.com/laispa)          |
+|     2     | [Fernando Vargas](http://www.github.com/SFernandoS) e [Luís Guilherme](http://www.github.com/luisgaboardi) |
+|     3     | [Lucas Rodrigues](http://www.github.com/nickby2) e [Luiz Gustavo](http://www.github.com/LightZX)           |
+
+## Sprint Backlog
+
+| Issue                                                                                                                                     | Pontos | Responsáveis                                                                                                                                                                                        |
+| ----------------------------------------------------------------------------------------------------------------------------------------- | :----: | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [Documentar revisão e retrospectiva da sprint 8](https://github.com//fga-eps-mds/2020.2-Projeto-Kokama-Wiki/issues/158)                   |   5    | [Welison Regis](https://github.com/WelisonR)                                                                                                                                                        |
+| [Criar documento de planejamento da sprint 9](https://github.com//fga-eps-mds/2020.2-Projeto-Kokama-Wiki/issues/157)                      |   2    | [Welison Regis](https://github.com/WelisonR)                                                                                                                                                        |
+| [Adicionar etapa de lint ao pipeline](https://github.com//fga-eps-mds/2020.2-Projeto-Kokama-Wiki/issues/156)                              |   5    | [Leonardo Medeiros](https://github.com/leomedeiros1)                                                                                                                                                |
+| [Interconectar os dockers através de uma network](https://github.com//fga-eps-mds/2020.2-Projeto-Kokama-Wiki/issues/154)                  |   3    | [Leonardo Medeiros](https://github.com/leomedeiros1)                                                                                                                                                |
+| [Criar scripts para possibilitar rodar o front-end fora do docker](https://github.com//fga-eps-mds/2020.2-Projeto-Kokama-Wiki/issues/153) |   5    | [Leonardo Medeiros](https://github.com/leomedeiros1) e [Welison Regis](https://github.com/WelisonR)                                                                                                 |
+| [[US14] Exercício de Múltipla Escolha no Front-End](https://github.com//fga-eps-mds/2020.2-Projeto-Kokama-Wiki/issues/152)                |   13   | [Fernando Vargas](https://github.com/SFernandoS) e [Luís Guilherme](https://github.com/luisgaboardi)                                                                                                |
+| [[US19] Tela com informações sobre o projeto](https://github.com//fga-eps-mds/2020.2-Projeto-Kokama-Wiki/issues/141)                      |   5    | [Lucas Rodrigues](https://github.com/nickby2) e [Luiz Gustavo](https://github.com/LightZX)                                                                                                          |
+| [US - História do povo Kokama disponíveis em português e Kokama](https://github.com//fga-eps-mds/2020.2-Projeto-Kokama-Wiki/issues/151)   |   13   | [Lais Portela](https://www.github.com/laispa) e [Ana Júlia](https://www.github.com/aluzianobriceno)                                                                                                 |
+| [TS06 - Refatoração e uso do repositório de Usuário](https://github.com//fga-eps-mds/2020.2-Projeto-Kokama-Wiki/issues/150)               |   40   | [André Lucas](https://github.com/andrelucax), [Lieverton Silva](https://github.com/lievertom), [Luís Guilherme](https://github.com/luisgaboardi) e [Fernando Vargas](https://github.com/SFernandoS) |
+
+**Observação**: devido a alta prioridade e complexidade da TS06, alocou-se, então, dois membros de EPS e dois membros de MDS para solucionar as pendências descritas na história técnica.
+
+## Papéis
+
+|         Papel         | Integrante        |
+| :-------------------: | ----------------- |
+|   **Scrum Master**    | Welison Regis     |
+|      **DevOps**       | Leonardo Medeiros |
+|     **Arquiteto**     | Lieverton Santos  |
+| **Analista de dados** | André Pinto       |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -90,6 +90,8 @@ nav:
       - Sprint 8:
         - Planejamento: "management/sprints/sprint-8-planning.md"
         - Revisão e retrospectiva: "management/sprints/sprint-8-review-retrospective.md"
+      - Sprint 9:
+        - Planejamento: "management/sprints/sprint-9-planning.md"
     - Reuniões com PO:
       - Reunião 1: "management/po-meetings/meeting-1.md"
       - Reunião 2: "management/po-meetings/meeting-2.md"


### PR DESCRIPTION
## Descrição 

Adiciona documentação do planejamento da sprint 9 para a wiki.

**Resolve #157**.

## Tarefas realizadas

- [x] Adiciona informações sobre a sprint;
- [x] Adiciona pareamentos da sprint;
- [x] Realiza adaptação nos pareamentos para atingir melhor produtividade nas entregas da equipe;
- [x] Adiciona atividades mapeadas para a sprint;
- [x] Adiciona papéis dos membros de EPS na sprint.